### PR TITLE
Add redirect to password page if assessment session is invalid

### DIFF
--- a/app/controllers/course/assessment/submission/submissions_controller.rb
+++ b/app/controllers/course/assessment/submission/submissions_controller.rb
@@ -135,6 +135,12 @@ class Course::Assessment::Submission::SubmissionsController < \
     params.permit(:answer_id, :reset_answer)
   end
 
+  def new_session_path
+    new_course_assessment_session_path(
+      current_course, @assessment, submission_id: @submission.id
+    )
+  end
+
   def check_password
     return unless @submission.attempting?
     return if !@assessment.password_protected? || can?(:manage, @assessment)
@@ -142,9 +148,10 @@ class Course::Assessment::Submission::SubmissionsController < \
     unless authentication_service.authenticated?
       log_service.log_submission_access(request)
 
-      redirect_to new_course_assessment_session_path(
-        current_course, @assessment, submission_id: @submission.id
-      )
+      respond_to do |format|
+        format.html { redirect_to new_session_path }
+        format.json { render json: { redirect_url: new_session_path, format: 'html' } }
+      end
     end
   end
 

--- a/client/app/bundles/course/assessment/submission/actions/index.js
+++ b/client/app/bundles/course/assessment/submission/actions/index.js
@@ -27,7 +27,7 @@ export function saveDraft(submissionId, answers) {
     return CourseAPI.assessment.submissions.update(submissionId, payload)
       .then(response => response.data)
       .then((data) => {
-        if (data.redirect_url) {
+        if (data.redirect_url && data.format === 'html') {
           window.location = data.redirect_url;
         }
         dispatch({
@@ -47,7 +47,7 @@ export function submit(submissionId, answers) {
     return CourseAPI.assessment.submissions.update(submissionId, payload)
       .then(response => response.data)
       .then((data) => {
-        if (data.redirect_url) {
+        if (data.redirect_url && data.format === 'html') {
           window.location = data.redirect_url;
         }
         dispatch({
@@ -117,7 +117,10 @@ export function autograde(submissionId, answers) {
     return CourseAPI.assessment.submissions.update(submissionId, payload)
       .then(response => response.data)
       .then((data) => {
-        if (data.redirect_url) {
+        if (data.redirect_url && data.format === 'html') {
+          window.location = data.redirect_url;
+        }
+        else if (data.redirect_url) {
           dispatch(pollEvaluation(data.redirect_url, submissionId, answers[0].id));
         } else {
           dispatch({


### PR DESCRIPTION
`format: 'html'` is needed to differentiate redirect to password page and redirect to autograding job json endpoint. There might be a better way to achieve this.