### PR TITLE
Autograding job in progress indicator

### DIFF
--- a/app/views/course/assessment/answer/programming/_programming.json.jbuilder
+++ b/app/views/course/assessment/answer/programming/_programming.json.jbuilder
@@ -12,6 +12,10 @@ json.fields do
   end
 end
 
+if answer.submitted? && job = answer.try(:auto_grading).try(:job)
+  json.job job_path(job) if job.submitted?
+end
+
 can_read_tests = can?(:read_tests, submission)
 show_private = can_read_tests || last_attempt&.correct? && assessment.show_private?
 show_evaluation = can_read_tests || last_attempt&.correct? && assessment.show_evaluation?

--- a/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/GradingPanel.jsx
@@ -216,7 +216,7 @@ VisibleGradingPanel.propTypes = {
 function mapStateToProps(state) {
   return {
     questions: state.questions,
-    submission: state.submissionEdit.submission,
+    submission: state.submission,
     grading: state.grading,
   };
 }

--- a/client/app/bundles/course/assessment/submission/containers/UploadedFileView.jsx
+++ b/client/app/bundles/course/assessment/submission/containers/UploadedFileView.jsx
@@ -107,7 +107,7 @@ VisibleUploadedFileView.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const { questionId } = ownProps;
-  const { submission } = state.submissionEdit;
+  const { submission } = state;
 
   const canDestroyAttachments =
     submission.workflowState === workflowStates.Attempting &&

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/SubmissionEditForm.jsx
@@ -6,12 +6,13 @@ import { reduxForm } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
+import CircularProgress from 'material-ui/CircularProgress';
 import RaisedButton from 'material-ui/RaisedButton';
 import { red900, yellow900, green900, red300, green500, white } from 'material-ui/styles/colors';
 
 /* eslint-disable import/extensions, import/no-extraneous-dependencies, import/no-unresolved */
 import ConfirmationDialog from 'lib/components/ConfirmationDialog';
-import { ExplanationProp, QuestionProp, TopicProp } from '../../propTypes';
+import { ExplanationProp, QuestionProp, QuestionFlagsProp, TopicProp } from '../../propTypes';
 import SubmissionAnswer from '../../components/SubmissionAnswer';
 import QuestionGrade from '../../containers/QuestionGrade';
 import GradingPanel from '../../containers/GradingPanel';
@@ -58,9 +59,10 @@ class SubmissionEditForm extends Component {
   }
 
   renderProgrammingQuestionActions(id) {
-    const { intl, attempting, questions, handleAutograde } = this.props;
+    const { intl, attempting, questions, questionsFlags, handleAutograde } = this.props;
     const question = questions[id];
     const { answerId } = question;
+    const { isAutograding, isResetting } = questionsFlags[id];
 
     if (!attempting) {
       return null;
@@ -74,6 +76,7 @@ class SubmissionEditForm extends Component {
             backgroundColor={white}
             label={intl.formatMessage(translations.reset)}
             onTouchTap={() => this.setState({ resetConfirmation: true, resetAnswerId: answerId })}
+            disabled={isAutograding || isResetting}
           />
           <RaisedButton
             style={styles.formButton}
@@ -81,7 +84,9 @@ class SubmissionEditForm extends Component {
             secondary
             label={intl.formatMessage(translations.submit)}
             onTouchTap={() => handleAutograde(answerId)}
+            disabled={isAutograding || isResetting}
           />
+          {isAutograding || isResetting ? <CircularProgress size={36} style={{ position: 'absolute' }} /> : null}
         </div>
       );
     }
@@ -380,6 +385,7 @@ SubmissionEditForm.propTypes = {
   explanations: PropTypes.objectOf(ExplanationProp),
   questionIds: PropTypes.arrayOf(PropTypes.number),
   questions: PropTypes.objectOf(QuestionProp),
+  questionsFlags: PropTypes.objectOf(QuestionFlagsProp),
   topics: PropTypes.objectOf(TopicProp),
   pristine: PropTypes.bool,
   submitting: PropTypes.bool,

--- a/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
+++ b/client/app/bundles/course/assessment/submission/pages/SubmissionEditIndex/index.jsx
@@ -12,8 +12,8 @@ import {
   unsubmit, autogradeAnswer, resetAnswer, saveGrade, mark, unmark, publish,
 } from '../../actions';
 import {
-  AnswerProp, AssessmentProp, ExplanationProp, GradingProp,
-  PostProp, QuestionProp, ReduxFormProp, SubmissionProp, TopicProp,
+  AnswerProp, AssessmentProp, ExplanationProp, GradingProp, PostProp,
+  QuestionFlagsProp, QuestionProp, ReduxFormProp, SubmissionProp, TopicProp,
 } from '../../propTypes';
 import { DATA_STATES, workflowStates } from '../../constants';
 
@@ -67,8 +67,9 @@ class VisibleSubmissionEditIndex extends Component {
   }
 
   handleReset(answerId) {
-    const { match: { params }, boundResetAnswer } = this.props;
-    boundResetAnswer(params.submissionId, answerId);
+    const { form, match: { params }, boundResetAnswer } = this.props;
+    const questionId = form.values[answerId].questionId;
+    boundResetAnswer(params.submissionId, answerId, questionId);
   }
 
   handleAutograde(answerId) {
@@ -108,6 +109,7 @@ class VisibleSubmissionEditIndex extends Component {
       explanations,
       posts,
       questions,
+      questionsFlags,
       topics,
       saveState,
     } = this.props;
@@ -134,6 +136,7 @@ class VisibleSubmissionEditIndex extends Component {
           posts={posts}
           questionIds={questionIds}
           questions={questions}
+          questionsFlags={questionsFlags}
           topics={topics}
           saveState={saveState}
         />
@@ -163,6 +166,7 @@ class VisibleSubmissionEditIndex extends Component {
         posts={posts}
         questionIds={questionIds}
         questions={questions}
+        questionsFlags={questionsFlags}
         tabbedView={tabbedView}
         topics={topics}
         delayedGradePublication={delayedGradePublication}
@@ -202,6 +206,7 @@ VisibleSubmissionEditIndex.propTypes = {
   grading: GradingProp.isRequired,
   posts: PropTypes.objectOf(PostProp),
   questions: PropTypes.objectOf(QuestionProp),
+  questionsFlags: PropTypes.objectOf(QuestionFlagsProp),
   submission: SubmissionProp,
   topics: PropTypes.objectOf(TopicProp),
   dataState: PropTypes.string.isRequired,
@@ -224,15 +229,15 @@ VisibleSubmissionEditIndex.propTypes = {
 function mapStateToProps(state) {
   return {
     answers: state.answers,
-    assessment: state.submissionEdit.assessment,
+    assessment: state.assessment,
     exp: state.grading.exp,
     explanations: state.explanations,
     form: state.form.submissionEdit,
     grading: state.grading.questions,
-    maxStep: state.submissionEdit.maxStep,
     posts: state.posts,
-    submission: state.submissionEdit.submission,
+    submission: state.submission,
     questions: state.questions,
+    questionsFlags: state.questionsFlags,
     topics: state.topics,
     dataState: state.submissionEdit.dataState,
     saveState: state.submissionEdit.saveState,
@@ -243,7 +248,7 @@ function mapDispatchToProps(dispatch) {
   return {
     boundFetchSubmission: id => dispatch(fetchSubmission(id)),
     boundAutogradeSubmission: id => dispatch(autogradeSubmission(id)),
-    boundResetAnswer: (id, answerId) => dispatch(resetAnswer(id, answerId)),
+    boundResetAnswer: (id, answerId, questionId) => dispatch(resetAnswer(id, answerId, questionId)),
     boundAutograde: (id, answers) => dispatch(autogradeAnswer(id, answers)),
     boundSaveDraft: (id, answers) => dispatch(saveDraft(id, answers)),
     boundSaveGrade: (id, grades, exp, published) => dispatch(saveGrade(id, grades, exp, published)),

--- a/client/app/bundles/course/assessment/submission/propTypes.js
+++ b/client/app/bundles/course/assessment/submission/propTypes.js
@@ -129,3 +129,9 @@ export const AnnotationProp =
     line: PropTypes.number.isRequired,
     postIds: PropTypes.arrayOf(PropTypes.number),
   });
+
+export const QuestionFlagsProp =
+  PropTypes.shape({
+    isAutograding: PropTypes.bool.isRequired,
+    isResetting: PropTypes.bool.isRequired,
+  });

--- a/client/app/bundles/course/assessment/submission/reducers/assessment.js
+++ b/client/app/bundles/course/assessment/submission/reducers/assessment.js
@@ -1,0 +1,10 @@
+import actions from '../constants';
+
+export default function (state = {}, action) {
+  switch (action.type) {
+    case actions.FETCH_SUBMISSION_SUCCESS:
+      return action.payload.assessment;
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/assessment/submission/reducers/index.js
+++ b/client/app/bundles/course/assessment/submission/reducers/index.js
@@ -3,11 +3,14 @@ import { reducer as form } from 'redux-form';
 import submissionEdit from './submissionEdit';
 import annotations from './annotations';
 import answers from './answers';
+import assessment from './assessment';
 import attachments from './attachments';
 import commentForms from './commentForms';
 import explanations from './explanations';
 import posts from './posts';
+import questionsFlags from './questionsFlags';
 import questions from './questions';
+import submission from './submission';
 import topics from './topics';
 import grading from './grading';
 import testCases from './testCases';
@@ -18,10 +21,13 @@ export default combineReducers({
   annotations,
   answers,
   attachments,
+  assessment,
   commentForms,
   explanations,
   posts,
+  questionsFlags,
   questions,
+  submission,
   topics,
   grading,
   testCases,

--- a/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
+++ b/client/app/bundles/course/assessment/submission/reducers/questionsFlags.js
@@ -1,0 +1,58 @@
+import actions from '../constants';
+
+export default function (state = {}, action) {
+  switch (action.type) {
+    case actions.FETCH_SUBMISSION_SUCCESS:
+      return action.payload.answers.reduce((obj, answer) => ({
+        ...obj,
+        [answer.questionId]: {
+          isResetting: false,
+          isAutograding: !!answer.job,
+        },
+      }), {});
+    case actions.AUTOGRADE_REQUEST: {
+      const { questionId } = action;
+      return {
+        ...state,
+        [questionId]: {
+          ...state[questionId],
+          isAutograding: true,
+        },
+      };
+    }
+    case actions.AUTOGRADE_SUCCESS:
+    case actions.AUTOGRADE_FAILURE: {
+      const { questionId } = action;
+      return {
+        ...state,
+        [questionId]: {
+          ...state[questionId],
+          isAutograding: false,
+        },
+      };
+    }
+    case actions.RESET_REQUEST: {
+      const { questionId } = action;
+      return {
+        ...state,
+        [questionId]: {
+          ...state[questionId],
+          isResetting: true,
+        },
+      };
+    }
+    case actions.RESET_SUCCESS:
+    case actions.RESET_FAILURE: {
+      const { questionId } = action;
+      return {
+        ...state,
+        [questionId]: {
+          ...state[questionId],
+          isResetting: false,
+        },
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/assessment/submission/reducers/submission.js
+++ b/client/app/bundles/course/assessment/submission/reducers/submission.js
@@ -1,0 +1,17 @@
+import actions from '../constants';
+
+export default function (state = {}, action) {
+  switch (action.type) {
+    case actions.FETCH_SUBMISSION_SUCCESS:
+    case actions.SAVE_DRAFT_SUCCESS:
+    case actions.SUBMISSION_SUCCESS:
+    case actions.UNSUBMIT_SUCCESS:
+    case actions.SAVE_GRADE_SUCCESS:
+    case actions.MARK_SUCCESS:
+    case actions.UNMARK_SUCCESS:
+    case actions.PUBLISH_SUCCESS:
+      return action.payload.submission;
+    default:
+      return state;
+  }
+}

--- a/client/app/bundles/course/assessment/submission/reducers/submissionEdit.js
+++ b/client/app/bundles/course/assessment/submission/reducers/submissionEdit.js
@@ -1,8 +1,6 @@
 import actions, { DATA_STATES, SAVE_STATES } from '../constants';
 
 const initialState = {
-  assessment: null,
-  submission: null,
   dataState: DATA_STATES.Unfetched,
   saveState: SAVE_STATES.Idle,
 };
@@ -17,8 +15,6 @@ export default function (state = initialState, action) {
     case actions.FETCH_SUBMISSION_SUCCESS:
       return {
         ...state,
-        assessment: action.payload.assessment,
-        submission: action.payload.submission,
         dataState: DATA_STATES.Received,
       };
     case actions.FETCH_SUBMISSION_FAILURE:
@@ -41,11 +37,6 @@ export default function (state = initialState, action) {
     case actions.MARK_SUCCESS:
     case actions.UNMARK_SUCCESS:
     case actions.PUBLISH_SUCCESS:
-      return {
-        ...state,
-        submission: action.payload.submission,
-        saveState: SAVE_STATES.Saved,
-      };
     case actions.AUTOGRADE_SUCCESS:
     case actions.RESET_SUCCESS:
       return {

--- a/client/app/bundles/course/assessment/submission/utils.js
+++ b/client/app/bundles/course/assessment/submission/utils.js
@@ -2,8 +2,8 @@
 import moment from 'lib/moment';
 
 export function arrayToObjectById(array) {
-  return array.reduce((obj, answer) => (
-    { ...obj, [answer.id]: answer }
+  return array.reduce((obj, item) => (
+    { ...obj, [item.id]: item }
   ), {});
 }
 


### PR DESCRIPTION
- Check for submitted auto grading jobs when fetching submission
- Show spinner when autograding answers
- Disable autograde and reset buttons when autograding or resetting answers
- Split out `submission`, `assessment` and `questionFlags` reducers from `submissionEdit`